### PR TITLE
[IMM-23883] - Public Gas charges method

### DIFF
--- a/contracts/Evaluator.sol
+++ b/contracts/Evaluator.sol
@@ -17,7 +17,7 @@ import {Require} from "./libraries/Require.sol";
 
 /**
  * @title Evaluator
- * @author Team Firefly <engineering@firefly.exchange>
+ * @author Team Bluefin <engineering@bluefin.io>
  * @notice Stores perpetual configurations and evaluates if a trade is allowed to be executed based on perpetual configurations.
  * Houses the variables needed to perform pre-trade checks for price, quantity and max allowed open interest.
  * Implements IEvalautor interface to allow contracts to acccess these variables

--- a/contracts/FundingOracle.sol
+++ b/contracts/FundingOracle.sol
@@ -17,7 +17,7 @@ import {Types} from "./libraries/Types.sol";
 
 /**
  * @title Funding Oracle
- * @author Team Bluefin <engineering@firefly.exchange>
+ * @author Team Bluefin <engineering@bluefin.io>
  * @notice Computes on-chain funding payments to be applied to traders for next 1 hour
  * @dev The contract is made upgradable using openzeppelin upgrades-pluging, don't change
  * the order of variables. Read more: https://docs.openzeppelin.com/upgrades-plugins/1.x/proxies

--- a/contracts/Guardian.sol
+++ b/contracts/Guardian.sol
@@ -19,7 +19,7 @@ import {Types} from "./libraries/Types.sol";
 
 /**
  * @title Guardian
- * @author Team Bluefin <engineering@firefly.exchange>
+ * @author Team Bluefin <engineering@bluefin.io>
  * @notice Guardian contract, able to control certain aspects of the protocol including:
  * 1. starting/stopping trade on a perpetual
  * 2. starting/stopping withdrawal of funds from margin bank

--- a/contracts/IsolatedADL.sol
+++ b/contracts/IsolatedADL.sol
@@ -20,7 +20,7 @@ import {Require} from "./libraries/Require.sol";
 
 /**
  * @title Isolated Auto Deleveraging
- * @author Team Bluefin <engineering@firefly.exchange>
+ * @author Team Bluefin <engineering@bluefin.io>
  * @notice Used to perform on-chain deleveraging of accounts.
  * The trade method on the contract is only invokable by the perpetual contract.
  * The ADL Operator or any account must invoke trade method on perpetual with trader

--- a/contracts/IsolatedLiquidation.sol
+++ b/contracts/IsolatedLiquidation.sol
@@ -22,7 +22,7 @@ import {Require} from "./libraries/Require.sol";
 
 /**
  * @title Isolated Liquidation
- * @author Team Bluefin <engineering@firefly.exchange>
+ * @author Team Bluefin <engineering@bluefin.io>
  * @notice Isolated Liquidation is a trader contract that executes liquidaiton trades.
  * The trade method on the contract is only invokable by the perpetual contract.
  * The liquidator must invoke trade() on perpetual to liquidate a position

--- a/contracts/MarginBank.sol
+++ b/contracts/MarginBank.sol
@@ -21,7 +21,7 @@ import {Require} from "./libraries/Require.sol";
 
 /**
  * @title Margin Bank
- * @author Team Bluefin <engineering@firefly.exchange>
+ * @author Team Bluefin <engineering@bluefin.io>
  * @notice Controls all the funds in perpetual protocol. Users must lock in their margin into margin bank
  * before it can be used to open any position on any perpetual market.
  * @dev When trades are executed to open/close position, the margin always remain in margin bank, just exchanges

--- a/contracts/interfaces/IIsolatedTrader.sol
+++ b/contracts/interfaces/IIsolatedTrader.sol
@@ -16,5 +16,5 @@ interface IIsolatedTrader {
         bytes calldata data,
         uint128 gasCharges,
         uint128 oraclePrice
-    ) external;
+    ) external returns (uint128, uint128);
 }

--- a/contracts/maths/MarginMath.sol
+++ b/contracts/maths/MarginMath.sol
@@ -9,7 +9,7 @@ import "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol";
 
 /**
  * @title Margin Math
- * @author Team Bluefin <engineering@firefly.exchange>
+ * @author Team Bluefin <engineering@bluefin.io>
  * @notice Computes margin to be moved out off or into the user position under different
  * circumstances
  */


### PR DESCRIPTION
The `_applyGasCharges` method was publically exposed and any one could invoke the method and move margin of an account to gas pool causing user trades to revert.

Changes:
- Made the `_applyGasCharges` method internal
- Added a public/external `applyCharges` method that could only be invoked by Perpetual contract
- The gas and fee charges are not moved to their respective pools during the trade call but instead the amounts are kept in perpetual and accrued to save transfer fee
- Added admin controlled methods to transfer fee/gas charges our of Perpetual
- Updated team email